### PR TITLE
Remember functionality, improve summary page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ bodyclass: "home"
         </li>
       </ul>
 
-      <a href="report-a-fault/" class="nhsuk-button nhsuk-u-margin-bottom-8">
+      <a id="start-button" href="report-a-fault/" class="nhsuk-button nhsuk-u-margin-bottom-8">
         Start now
       </a>
 

--- a/js/shared.js
+++ b/js/shared.js
@@ -14,3 +14,57 @@ $('[data-form-action]').on('change', function() {
   }
 
 });
+
+$('form').on('submit', function() {
+    var $form = $(this);
+    var next = $form.attr('action');
+    var remembered = JSON.parse(localStorage.getItem('remembered') || '{}');
+    var box = document.getElementById('remember');
+    if (box) {
+        var current = location.pathname;
+        if (box.checked) {
+            remembered[current] = {
+                'answers': $form.serializeArray(),
+                'next': next,
+            };
+        } else {
+            delete remembered[current];
+        }
+        localStorage.setItem('remembered', JSON.stringify(remembered));
+    }
+    var action = skipPage(next, remembered);
+    if (action) {
+        $form.attr('action', action);
+    }
+});
+
+// Initial start might cause a skip too
+$('#start-button').on('click', function(e) {
+    var remembered = JSON.parse(localStorage.getItem('remembered') || '{}');
+    var action = skipPage('/report-a-fault/location-id/', remembered);
+    if (action) {
+        updateState('id-known', 'yes');
+        e.preventDefault();
+        location.href = action;
+        return;
+    }
+    action = skipPage('/report-a-fault/location-site/', remembered);
+    if (action) {
+        updateState('id-known', 'no');
+        e.preventDefault();
+        location.href = action;
+        return;
+    }
+});
+
+function skipPage(page, remembered) {
+    var newPage;
+    while (remembered[page]) {
+        remembered[page]['answers'].forEach(function(a) {
+            updateState(a.name, a.value);
+        });
+        page = remembered[page]['next'];
+        newPage = page;
+    }
+    return newPage;
+}

--- a/report-a-fault/contact-details.html
+++ b/report-a-fault/contact-details.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Contact details"
 permalink: report-a-fault/contact-details/
-action: "report-a-fault/summary"
+action: "report-a-fault/summary/"
 ---
       <h1 class="nhsuk-heading-l">Contact details</h1>
 

--- a/report-a-fault/contact-details.html
+++ b/report-a-fault/contact-details.html
@@ -39,7 +39,7 @@ action: "report-a-fault/summary/"
       <div class="nhsuk-form-group">
         <div class="nhsuk-checkboxes">
           <div class="nhsuk-checkboxes__item">
-            <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+            <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
             <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
               Remember my answers for next time
             </label>

--- a/report-a-fault/describe-fault.html
+++ b/report-a-fault/describe-fault.html
@@ -12,6 +12,43 @@ action: "report-a-fault/equipment-details/"
       </h1>
     </legend>
 
+    <p data-stateful-key="id-known" data-stateful-showif="yes">
+      Reporting a fault at location ID <strong class="js-stateful" data-stateful-key="location-id"></strong>
+
+        <span data-stateful-key="restricted" data-stateful-showif="restricted">
+            <br>Access restricted:
+            <strong class="js-stateful" data-stateful-key="access-restriction-details"></strong>
+        </span>
+
+      (<a href="{{ 'report-a-fault/location-id/' | relative_url }}">change</a>)
+    </p>
+
+    <p data-stateful-key="id-known" data-stateful-showif="no">
+      Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span>,
+        <span class="js-stateful" data-stateful-key="building"></span>,
+        floor <strong class="js-stateful" data-stateful-key="floor"></strong>,
+
+        <span data-stateful-key="place" data-stateful-showif="place-common">
+            common or outdoor area,
+            <strong class="js-stateful" data-stateful-key="area"></strong>
+        </span>
+        <span data-stateful-key="place" data-stateful-showif="place-other">
+            other location,
+            <strong class="js-stateful" data-stateful-key="area"></strong>
+        </span>
+        <span data-stateful-key="place" data-stateful-showif="place-dept">
+            ward <strong class="js-stateful" data-stateful-key="dept"></strong>,
+            room <strong class="js-stateful" data-stateful-key="room-no"></strong>
+        </span>
+
+        <span data-stateful-key="restricted" data-stateful-showif="restricted">
+            <br>Access restricted:
+            <strong class="js-stateful" data-stateful-key="access-restriction-details"></strong>
+        </span>
+
+      (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)
+    </p>
+
 
     <div class="nhsuk-form-group">
       <label class="nhsuk-label" for="fault-description">

--- a/report-a-fault/describe-fault.html
+++ b/report-a-fault/describe-fault.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault description"
 permalink: report-a-fault/describe-fault/
-action: "report-a-fault/equipment-details"
+action: "report-a-fault/equipment-details/"
 ---
 
   <fieldset class="nhsuk-fieldset">

--- a/report-a-fault/equipment-details.html
+++ b/report-a-fault/equipment-details.html
@@ -18,7 +18,7 @@ action: "report-a-fault/photo/"
         Asset ID
       </label>
       <div class="nhsuk-hint asset-id-hint" id="asset-id-hint">
-        If there is a visible asset tag on the equipment enter it below. <a href="{{ 'report-a-fault/find-an-asset-id/'' | relative_url }}">Get help finding an asset tag</a>
+        If there is a visible asset tag on the equipment enter it below. <a href="{{ 'report-a-fault/find-an-asset-id/' | relative_url }}">Get help finding an asset tag</a>
       </div>
       <input class="nhsuk-input js-stateful" id="asset-id" name="asset-id" type="text">
     </div>

--- a/report-a-fault/equipment-details.html
+++ b/report-a-fault/equipment-details.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Equipment or fitting details"
 permalink: report-a-fault/equipment-details/
-action: "report-a-fault/photo"
+action: "report-a-fault/photo/"
 ---
 
   <fieldset class="nhsuk-fieldset">

--- a/report-a-fault/index.html
+++ b/report-a-fault/index.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - location ID"
 bodyclass: "question"
-action: "report-a-fault/location-site"
+action: "report-a-fault/location-site/"
 ---
 <div class="nhsuk-form-group">
   <fieldset class="nhsuk-fieldset">
@@ -19,14 +19,14 @@ action: "report-a-fault/location-site"
     <div class="nhsuk-radios">
 
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input js-stateful" id="yes" name="id-known" type="radio" value="yes" data-form-action="{{ 'report-a-fault/location-id' | relative_url }}">
+        <input class="nhsuk-radios__input js-stateful" id="yes" name="id-known" type="radio" value="yes" data-form-action="{{ 'report-a-fault/location-id/' | relative_url }}">
         <label class="nhsuk-label nhsuk-radios__label" for="yes">
           Yes
         </label>
       </div>
 
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input js-stateful" id="no" name="id-known" type="radio" value="no" data-form-action="{{ 'report-a-fault/location-site' | relative_url }}">
+        <input class="nhsuk-radios__input js-stateful" id="no" name="id-known" type="radio" value="no" data-form-action="{{ 'report-a-fault/location-site/' | relative_url }}">
         <label class="nhsuk-label nhsuk-radios__label" for="no">
           No, try another way
         </label>

--- a/report-a-fault/index.html
+++ b/report-a-fault/index.html
@@ -13,7 +13,7 @@ action: "report-a-fault/location-site/"
     </legend>
 
     <div class="nhsuk-hint">
-      A way of uniquely identifying a location in your trust, sometimes called a room reference, or PFI number. <a href="{{ 'report-a-fault/find-a-location-id/'' | relative_url }}">Help finding location IDs</a>
+      A way of uniquely identifying a location in your trust, sometimes called a room reference, or PFI number. <a href="{{ 'report-a-fault/find-a-location-id/' | relative_url }}">Help finding location IDs</a>
     </div>
 
     <div class="nhsuk-radios">

--- a/report-a-fault/location-building.html
+++ b/report-a-fault/location-building.html
@@ -11,24 +11,26 @@ action: "report-a-fault/location-place/"
       </h1>
     </legend>
 
+      <p>Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span> (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)</p>
+
     <div class="nhsuk-radios nhsuk-u-margin-bottom-4">
 
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input js-stateful" id="building-a" name="building" type="radio" value="building-a">
+        <input class="nhsuk-radios__input js-stateful" id="building-a" name="building" type="radio" value="Building A">
         <label class="nhsuk-label nhsuk-radios__label" for="building-a">
           Building A
         </label>
       </div>
 
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input js-stateful" id="building-b" name="building" type="radio" value="building-b">
+        <input class="nhsuk-radios__input js-stateful" id="building-b" name="building" type="radio" value="Building B">
         <label class="nhsuk-label nhsuk-radios__label" for="building-b">
           Building B
         </label>
       </div>
 
       <div class="nhsuk-radios__item">
-        <input class="nhsuk-radios__input js-stateful" id="building-other" name="building" type="radio" value="building-other">
+        <input class="nhsuk-radios__input js-stateful" id="building-other" name="building" type="radio" value="Building - Other">
         <label class="nhsuk-label nhsuk-radios__label" for="building-other">
           Other
         </label>

--- a/report-a-fault/location-building.html
+++ b/report-a-fault/location-building.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - Building"
 permalink: report-a-fault/location-building/
-action: "report-a-fault/location-place"
+action: "report-a-fault/location-place/"
 ---
   <fieldset class="nhsuk-fieldset">
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">

--- a/report-a-fault/location-building.html
+++ b/report-a-fault/location-building.html
@@ -54,7 +54,7 @@ action: "report-a-fault/location-place/"
   <div class="nhsuk-form-group">
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+        <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
           Remember my answers for next time
         </label>

--- a/report-a-fault/location-common.html
+++ b/report-a-fault/location-common.html
@@ -20,7 +20,7 @@ action: "report-a-fault/describe-fault/"
         <div class="nhsuk-hint area-description-hint" id="area-description-hint">
           Do your best to describe the area so that an inspector can easily find it.
         </div>
-        <textarea class="nhsuk-textarea js-stateful" id="area" name="are" rows="5" aria-describedby="area-description-hint"></textarea>
+        <textarea class="nhsuk-textarea js-stateful" id="area" name="area" rows="5" aria-describedby="area-description-hint"></textarea>
         </div>
 
         <div class="nhsuk-form-group">   

--- a/report-a-fault/location-common.html
+++ b/report-a-fault/location-common.html
@@ -37,3 +37,14 @@ action: "report-a-fault/describe-fault/"
             </div>
         </div>
       </div>
+
+    <div class="nhsuk-form-group">
+      <div class="nhsuk-checkboxes">
+        <div class="nhsuk-checkboxes__item">
+          <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
+          <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
+            Remember my answers for next time
+          </label>
+        </div>
+      </div>
+    </div>

--- a/report-a-fault/location-common.html
+++ b/report-a-fault/location-common.html
@@ -11,7 +11,11 @@ action: "report-a-fault/describe-fault/"
         </h1>
       </legend>
 
-      <p>Reporting a fault at Site A, building B (<a href="{{ 'report-a-problem/location-site' | relative_url }}">change</a>)</p>
+      <p>Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span>,
+        <span class="js-stateful" data-stateful-key="building"></span>,
+        floor <span class="js-stateful" data-stateful-key="floor"></span>,
+        <span class="js-stateful" data-stateful-key="place"></span>
+      (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)</p>
   
       <div class="nhsuk-form-group" data-stateful-key="area">
         <label class="nhsuk-label" for="area">

--- a/report-a-fault/location-common.html
+++ b/report-a-fault/location-common.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - Common area or other"
 permalink: report-a-fault/location-common/
-action: "report-a-fault/describe-fault"
+action: "report-a-fault/describe-fault/"
 ---
     <fieldset class="nhsuk-fieldset">
       <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
@@ -26,7 +26,7 @@ action: "report-a-fault/describe-fault"
         <div class="nhsuk-form-group">   
           <div class="nhsuk-checkboxes">
             <div class="nhsuk-checkboxes__item">
-              <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted' | relative_url }}">
+              <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted/' | relative_url }}">
               <label class="nhsuk-label nhsuk-checkboxes__label" for="restricted">
                 Access to this location is restricted
               </label>

--- a/report-a-fault/location-dept.html
+++ b/report-a-fault/location-dept.html
@@ -6,7 +6,12 @@ action: "report-a-fault/describe-fault/"
 ---
 
     <h1 class="nhsuk-heading-l">Where is the fault?</h1>
-    <p>Reporting a fault at Site A, building B (<a href="{{ 'report-a-problem/location-site' | relative_url }}">change</a>)</p>
+
+      <p>Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span>,
+        <span class="js-stateful" data-stateful-key="building"></span>,
+        floor <span class="js-stateful" data-stateful-key="floor"></span>,
+        in a ward/clinic/department
+      (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)</p>
 
     <div class="nhsuk-form-group" data-stateful-key="dept">
       <label class="nhsuk-label" for="dept">

--- a/report-a-fault/location-dept.html
+++ b/report-a-fault/location-dept.html
@@ -20,7 +20,7 @@ action: "report-a-fault/describe-fault/"
         Room number or room description
       </label>
       <div class="nhsuk-hint room-no-description-hint" id="room-no-description-hint">
-        Rooms should have a number on the door. If a room number is not available, give an accurate description. <a href="{{ 'report-a-fault/find-a-location-id/'' | relative_url }}">Help finding room numbers</a>
+        Rooms should have a number on the door. If a room number is not available, give an accurate description. <a href="{{ 'report-a-fault/find-a-location-id/' | relative_url }}">Help finding room numbers</a>
       </div>
       <input class="nhsuk-input js-stateful" id="room-no" name="room-no" type="text">
     </div>

--- a/report-a-fault/location-dept.html
+++ b/report-a-fault/location-dept.html
@@ -39,7 +39,7 @@ action: "report-a-fault/describe-fault/"
     <div class="nhsuk-form-group">
       <div class="nhsuk-checkboxes">
         <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+          <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
             Remember my answers for next time
           </label>

--- a/report-a-fault/location-dept.html
+++ b/report-a-fault/location-dept.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - Ward, clinic or department"
 permalink: report-a-fault/location-dept/
-action: "report-a-fault/describe-fault"
+action: "report-a-fault/describe-fault/"
 ---
 
     <h1 class="nhsuk-heading-l">Where is the fault?</h1>
@@ -28,7 +28,7 @@ action: "report-a-fault/describe-fault"
     <div class="nhsuk-form-group">
       <div class="nhsuk-checkboxes">
         <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted' | relative_url }}">
+          <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted/' | relative_url }}">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="restricted">
             Access to this location is restricted
           </label>

--- a/report-a-fault/location-id.html
+++ b/report-a-fault/location-id.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Location ID"
 permalink: report-a-fault/location-id/
-action: "report-a-fault/describe-fault"
+action: "report-a-fault/describe-fault/"
 ---
 
   <div class="nhsuk-form-group">
@@ -27,7 +27,7 @@ action: "report-a-fault/describe-fault"
     <div class="nhsuk-checkboxes">
 
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted' | relative_url }}">
+        <input class="nhsuk-checkboxes__input js-stateful" id="restricted" name="restricted" type="checkbox" value="restricted" data-form-action="{{ 'report-a-fault/location-restricted/' | relative_url }}">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="restricted">
           Access to this location is restricted
         </label>

--- a/report-a-fault/location-id.html
+++ b/report-a-fault/location-id.html
@@ -13,6 +13,8 @@ action: "report-a-fault/describe-fault/"
         </h1>
       </legend>
   
+      <p>Reporting a fault with asset ID (<a href="{{ 'report-a-fault/' | relative_url }}">change</a>)</p>
+
       <div class="nhsuk-form-group">
         <label class="nhsuk-label" for="location-id">
           Location ID

--- a/report-a-fault/location-id.html
+++ b/report-a-fault/location-id.html
@@ -39,7 +39,7 @@ action: "report-a-fault/describe-fault/"
   <div class="nhsuk-form-group">
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+        <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
           Remember my answers for next time
         </label>

--- a/report-a-fault/location-place.html
+++ b/report-a-fault/location-place.html
@@ -43,7 +43,7 @@ action: "report-a-fault/location-dept/"
   <div class="nhsuk-form-group">
       <div class="nhsuk-checkboxes">
         <div class="nhsuk-checkboxes__item">
-          <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+          <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
           <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
             Remember my answers for next time
           </label>

--- a/report-a-fault/location-place.html
+++ b/report-a-fault/location-place.html
@@ -13,7 +13,7 @@ action: "report-a-fault/location-dept/"
         </h1>
       </legend>
 
-      <p>Reporting a fault at Site A, building B (<a href="{{ 'report-a-problem/location-site' | relative_url }}">change</a>)</p>
+      <p>Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span>, <span class="js-stateful" data-stateful-key="building"></span>, floor <span class="js-stateful" data-stateful-key="floor"></span> (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)</p>
   
       <div class="nhsuk-radios">
   

--- a/report-a-fault/location-place.html
+++ b/report-a-fault/location-place.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - Place"
 permalink: report-a-fault/location-place/
-action: "report-a-fault/location-dept"
+action: "report-a-fault/location-dept/"
 ---
 
   <div class="nhsuk-form-group">
@@ -18,21 +18,21 @@ action: "report-a-fault/location-dept"
       <div class="nhsuk-radios">
   
         <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input js-stateful" id="place-dept" name="place" type="radio" value="place-dept" data-form-action="{{ 'report-a-fault/location-dept' | relative_url }}">
+          <input class="nhsuk-radios__input js-stateful" id="place-dept" name="place" type="radio" value="place-dept" data-form-action="{{ 'report-a-fault/location-dept/' | relative_url }}">
           <label class="nhsuk-label nhsuk-radios__label" for="place-dept">
             A ward, clinic, or department
           </label>
         </div>
   
         <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input js-stateful" id="place-common" name="place" type="radio" value="place-common" data-form-action="{{ 'report-a-fault/location-common' | relative_url }}">
+          <input class="nhsuk-radios__input js-stateful" id="place-common" name="place" type="radio" value="place-common" data-form-action="{{ 'report-a-fault/location-common/' | relative_url }}">
           <label class="nhsuk-label nhsuk-radios__label" for="place-common">
             A common or outdoor area
           </label>
         </div>
 
         <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input js-stateful" id="place-other" name="place" type="radio" value="place-other" data-form-action="{{ 'report-a-fault/location-common' | relative_url }}">
+          <input class="nhsuk-radios__input js-stateful" id="place-other" name="place" type="radio" value="place-other" data-form-action="{{ 'report-a-fault/location-common/' | relative_url }}">
           <label class="nhsuk-label nhsuk-radios__label" for="place-other">
             Other
           </label>

--- a/report-a-fault/location-restricted.html
+++ b/report-a-fault/location-restricted.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Access restriction"
 permalink: report-a-fault/location-restricted/
-action: "report-a-fault/describe-fault"
+action: "report-a-fault/describe-fault/"
 ---
 
   <div class="nhsuk-form-group">

--- a/report-a-fault/location-restricted.html
+++ b/report-a-fault/location-restricted.html
@@ -29,7 +29,7 @@ action: "report-a-fault/describe-fault/"
   <div class="nhsuk-form-group">
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+        <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
           Remember my answers for next time
         </label>

--- a/report-a-fault/location-restricted.html
+++ b/report-a-fault/location-restricted.html
@@ -13,6 +13,40 @@ action: "report-a-fault/describe-fault/"
         </h1>
       </legend>
 
+    <p data-stateful-key="id-known" data-stateful-showif="yes">
+      Reporting a fault at location ID <strong class="js-stateful" data-stateful-key="location-id"></strong>
+        <span data-stateful-key="restricted" data-stateful-showif="restricted">
+            <em>access restricted</em>
+        </span>
+
+      (<a href="{{ 'report-a-fault/location-id/' | relative_url }}">change</a>)
+    </p>
+
+    <p data-stateful-key="id-known" data-stateful-showif="no">
+      Reporting a fault at <span class="js-stateful" data-stateful-key="site"></span>,
+        <span class="js-stateful" data-stateful-key="building"></span>,
+        floor <strong class="js-stateful" data-stateful-key="floor"></strong>,
+
+        <span data-stateful-key="place" data-stateful-showif="place-common">
+            common or outdoor area,
+            <strong class="js-stateful" data-stateful-key="area"></strong>,
+        </span>
+        <span data-stateful-key="place" data-stateful-showif="place-other">
+            other location,
+            <strong class="js-stateful" data-stateful-key="area"></strong>,
+        </span>
+        <span data-stateful-key="place" data-stateful-showif="place-dept">
+            ward <strong class="js-stateful" data-stateful-key="dept"></strong>,
+            room <strong class="js-stateful" data-stateful-key="room-no"></strong>
+        </span>
+
+        <span data-stateful-key="restricted" data-stateful-showif="restricted">
+            <em>access restricted</em>
+        </span>
+
+      (<a href="{{ 'report-a-fault/location-site/' | relative_url }}">change</a>)
+    </p>
+
       <div class="nhsuk-form-group nhsuk-u-margin-bottom-4">
         <label class="nhsuk-label" for="access-restriction-details">
           Access restriction details

--- a/report-a-fault/location-site.html
+++ b/report-a-fault/location-site.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Fault location - Site"
 permalink: report-a-fault/location-site/
-action: "report-a-fault/location-building"
+action: "report-a-fault/location-building/"
 ---
 
   <div class="nhsuk-form-group">

--- a/report-a-fault/location-site.html
+++ b/report-a-fault/location-site.html
@@ -37,7 +37,7 @@ action: "report-a-fault/location-building/"
   <div class="nhsuk-form-group">
     <div class="nhsuk-checkboxes">
       <div class="nhsuk-checkboxes__item">
-        <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+        <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
         <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
           Remember my answers for next time
         </label>

--- a/report-a-fault/location-site.html
+++ b/report-a-fault/location-site.html
@@ -13,17 +13,19 @@ action: "report-a-fault/location-building/"
         </h1>
       </legend>
   
+      <p>Reporting a fault without asset ID (<a href="{{ 'report-a-fault/' | relative_url }}">change</a>)</p>
+
       <div class="nhsuk-radios">
   
         <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input js-stateful" id="site-a" name="site" type="radio" value="site a">
+          <input class="nhsuk-radios__input js-stateful" id="site-a" name="site" type="radio" value="Site A">
           <label class="nhsuk-label nhsuk-radios__label" for="site-a">
             Site A
           </label>
         </div>
   
         <div class="nhsuk-radios__item">
-          <input class="nhsuk-radios__input js-stateful" id="site-b" name="site" type="radio" value="site b">
+          <input class="nhsuk-radios__input js-stateful" id="site-b" name="site" type="radio" value="Site B">
           <label class="nhsuk-label nhsuk-radios__label" for="site-b">
             Site B
           </label>

--- a/report-a-fault/photo.html
+++ b/report-a-fault/photo.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Photo"
 permalink: report-a-fault/photo/
-action: "report-a-fault/reporter-details"
+action: "report-a-fault/reporter-details/"
 ---
 
   <fieldset class="nhsuk-fieldset">

--- a/report-a-fault/reporter-details.html
+++ b/report-a-fault/reporter-details.html
@@ -2,7 +2,7 @@
 layout: question
 title: "Contact details"
 permalink: report-a-fault/reporter-details/
-action: "report-a-fault/summary"
+action: "report-a-fault/summary/"
 ---
     <h1 class="nhsuk-heading-l">
       Reporter details
@@ -38,14 +38,14 @@ action: "report-a-fault/summary"
         <div class="nhsuk-radios nhsuk-u-margin-bottom-4">
           <legend><p>Who should we contact about this report?</p></legend>
           <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input js-stateful" id="place-dept" name="updates-details" type="radio" value="send-to-me" data-form-action="{{ 'report-a-fault/summary' | relative_url }}" checked="checked">
+            <input class="nhsuk-radios__input js-stateful" id="place-dept" name="updates-details" type="radio" value="send-to-me" data-form-action="{{ 'report-a-fault/summary/' | relative_url }}" checked="checked">
             <label class="nhsuk-label nhsuk-radios__label" for="place-dept">
               Me
             </label>
           </div>
     
           <div class="nhsuk-radios__item">
-            <input class="nhsuk-radios__input js-stateful" id="place-common" name="updates-details" type="radio" value="send-to-someone-else" data-form-action="{{ 'report-a-fault/contact-details' | relative_url }}">
+            <input class="nhsuk-radios__input js-stateful" id="place-common" name="updates-details" type="radio" value="send-to-someone-else" data-form-action="{{ 'report-a-fault/contact-details/' | relative_url }}">
             <label class="nhsuk-label nhsuk-radios__label" for="place-common">
               Someone else
             </label>

--- a/report-a-fault/reporter-details.html
+++ b/report-a-fault/reporter-details.html
@@ -57,7 +57,7 @@ action: "report-a-fault/summary/"
       <div class="nhsuk-form-group">
         <div class="nhsuk-checkboxes">
           <div class="nhsuk-checkboxes__item">
-            <input class="nhsuk-checkboxes__input js-stateful" id="remember" type="checkbox" value="remember" disabled="disabled">
+            <input class="nhsuk-checkboxes__input" id="remember" type="checkbox" value="remember">
             <label class="nhsuk-label nhsuk-checkboxes__label" for="remember">
               Remember my answers for next time
             </label>

--- a/report-a-fault/summary.html
+++ b/report-a-fault/summary.html
@@ -16,7 +16,7 @@ bodyclass: "summary"
   <h2>Location</h2>
   <dl class="nhsuk-summary-list">
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="id-known" data-stateful-showif="yes">
       <dt class="nhsuk-summary-list__key">
         Location ID
       </dt>
@@ -31,7 +31,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="id-known" data-stateful-showif="no">
       <dt class="nhsuk-summary-list__key">
        Site
       </dt>
@@ -46,7 +46,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="id-known" data-stateful-showif="no">
       <dt class="nhsuk-summary-list__key">
         Building
       </dt>
@@ -61,7 +61,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="building" data-stateful-showif="building-other">
       <dt class="nhsuk-summary-list__key">
         Building - other
       </dt>
@@ -76,7 +76,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="id-known" data-stateful-showif="no">
       <dt class="nhsuk-summary-list__key">
         Floor
       </dt>
@@ -91,7 +91,7 @@ bodyclass: "summary"
       </dd>   
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="id-known" data-stateful-showif="no">
       <dt class="nhsuk-summary-list__key">
         Place
       </dt>
@@ -106,7 +106,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="place" data-stateful-showif="place-dept">
       <dt class="nhsuk-summary-list__key">
         Department, ward or clinic
       </dt>
@@ -121,7 +121,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="place" data-stateful-showif="place-common">
       <dt class="nhsuk-summary-list__key">
         Area description
       </dt>
@@ -136,7 +136,22 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="place" data-stateful-showif="place-other">
+      <dt class="nhsuk-summary-list__key">
+        Area description
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <p class="js-stateful" data-stateful-key="area"></p>
+      </dd>
+
+      <dd class="nhsuk-summary-list__actions">
+        <a href="#">
+          Change<span class="nhsuk-u-visually-hidden"> area</span>
+        </a>
+      </dd>
+    </div>
+
+    <div class="nhsuk-summary-list__row" data-stateful-key="place" data-stateful-showif="place-dept">
       <dt class="nhsuk-summary-list__key">
         Room number
       </dt>
@@ -156,7 +171,8 @@ bodyclass: "summary"
         Restricted access?
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <p class="js-stateful" data-stateful-key="restricted"></p>
+        <p data-stateful-key="restricted" data-stateful-showif="restricted">Yes</p>
+        <p data-stateful-key="restricted" data-stateful-hideif="restricted">No</p>
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
@@ -166,7 +182,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="restricted" data-stateful-showif="restricted">
       <dt class="nhsuk-summary-list__key">
         Access restrictions
       </dt>
@@ -278,7 +294,7 @@ bodyclass: "summary"
     </div>
   
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="updates-details" data-stateful-showif="send-to-someone-else">
       <dt class="nhsuk-summary-list__key">
         Contact name
       </dt>
@@ -292,7 +308,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="updates-details" data-stateful-showif="send-to-someone-else">
       <dt class="nhsuk-summary-list__key">
         Contact email
       </dt>
@@ -306,7 +322,7 @@ bodyclass: "summary"
       </dd>
     </div>
 
-    <div class="nhsuk-summary-list__row">
+    <div class="nhsuk-summary-list__row" data-stateful-key="updates-details" data-stateful-showif="send-to-someone-else">
       <dt class="nhsuk-summary-list__key">
         Contact phone
       </dt>

--- a/report-a-fault/summary.html
+++ b/report-a-fault/summary.html
@@ -81,7 +81,7 @@ bodyclass: "summary"
         Floor
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <p class="j s-stateful" data-stateful-key="floor"></p>
+        <p class="js-stateful" data-stateful-key="floor"></p>
       </dd>
   
       <dd class="nhsuk-summary-list__actions">

--- a/report-a-fault/summary.html
+++ b/report-a-fault/summary.html
@@ -12,7 +12,7 @@ bodyclass: "summary"
 
 <h1>Summary</h1>
 <div class="summary">
-  <form action="{{ 'report-a-fault/confirmation' | relative_url }}" method="get">
+  <form action="{{ 'report-a-fault/confirmation/' | relative_url }}" method="get">
   <h2>Location</h2>
   <dl class="nhsuk-summary-list">
 

--- a/report-a-fault/summary.html
+++ b/report-a-fault/summary.html
@@ -25,7 +25,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-id/">
           Change<span class="nhsuk-u-visually-hidden"> location id</span>
         </a>
       </dd>
@@ -40,7 +40,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-site/">
           Change<span class="nhsuk-u-visually-hidden"> site</span>
         </a>
       </dd>
@@ -55,7 +55,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-building/">
           Change<span class="nhsuk-u-visually-hidden"> building</span>
         </a>
       </dd>
@@ -70,7 +70,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-building/">
           Change<span class="nhsuk-u-visually-hidden"> building</span>
         </a>
       </dd>
@@ -85,7 +85,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-building/">
           Change<span class="nhsuk-u-visually-hidden"> floor</span>
         </a>
       </dd>   
@@ -100,7 +100,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-place/">
           Change<span class="nhsuk-u-visually-hidden"> Place</span>
         </a>
       </dd>
@@ -115,7 +115,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-dept/">
           Change<span class="nhsuk-u-visually-hidden"> department, ward or clinic</span>
         </a>
       </dd>
@@ -130,7 +130,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-common/">
           Change<span class="nhsuk-u-visually-hidden"> area</span>
         </a>
       </dd>
@@ -145,7 +145,7 @@ bodyclass: "summary"
       </dd>
 
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-common/">
           Change<span class="nhsuk-u-visually-hidden"> area</span>
         </a>
       </dd>
@@ -160,7 +160,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-dept/">
           Change<span class="nhsuk-u-visually-hidden"> room number</span>
         </a>
       </dd>
@@ -176,9 +176,10 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
-          Change<span class="nhsuk-u-visually-hidden"> restriction</span>
-        </a>
+        <a data-stateful-key="place" data-stateful-showif="place-common" href="../location-common/">Change<span class="nhsuk-u-visually-hidden"> restriction</span></a>
+        <a data-stateful-key="place" data-stateful-showif="place-other" href="../location-common/">Change<span class="nhsuk-u-visually-hidden"> restriction</span></a>
+        <a data-stateful-key="place" data-stateful-showif="place-dept" href="../location-dept/">Change<span class="nhsuk-u-visually-hidden"> restriction</span></a>
+        <a data-stateful-key="id-known" data-stateful-showif="yes" href="../location-id/">Change<span class="nhsuk-u-visually-hidden"> restriction</span></a>
       </dd>
     </div>
 
@@ -191,7 +192,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../location-restricted/">
           Change<span class="nhsuk-u-visually-hidden"> restriction details</span>
         </a>
       </dd>
@@ -211,7 +212,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../describe-fault/">
           Change<span class="nhsuk-u-visually-hidden"> description</span>
         </a>
       </dd>
@@ -226,7 +227,7 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../equipment-details/">
           Change<span class="nhsuk-u-visually-hidden"> asset ID</span>
         </a>
       </dd>
@@ -241,7 +242,9 @@ bodyclass: "summary"
       </dd>
   
       <dd class="nhsuk-summary-list__actions">
-        
+      <a href="../photo/">
+          Change<span class="nhsuk-u-visually-hidden"> photo</span>
+        </a>
       </dd>
     </div>
   </dl>
@@ -259,7 +262,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="reporter-name">not set!</p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../reporter-details/">
           Change<span class="nhsuk-u-visually-hidden"> name</span>
         </a>
       </dd>
@@ -273,7 +276,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="reporter-email"></p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../reporter-details/">
           Change<span class="nhsuk-u-visually-hidden"> email</span>
         </a>
       </dd>
@@ -287,7 +290,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="reporter-phone"></p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../reporter-details/">
           Change<span class="nhsuk-u-visually-hidden"> phone</span>
         </a>
       </dd>
@@ -302,7 +305,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="contact-name"></p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../contact-details/">
           Change<span class="nhsuk-u-visually-hidden"> contact name</span>
         </a>
       </dd>
@@ -316,7 +319,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="contact-email"></p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../contact-details/">
           Change<span class="nhsuk-u-visually-hidden"> contact email</span>
         </a>
       </dd>
@@ -330,7 +333,7 @@ bodyclass: "summary"
        <p class="js-stateful" data-stateful-key="contact-phone"></p>
       </dd>
       <dd class="nhsuk-summary-list__actions">
-        <a href="#">
+        <a href="../contact-details/">
           Change<span class="nhsuk-u-visually-hidden"> contact phone</span>
         </a>
       </dd>


### PR DESCRIPTION
If remember is ticked on a page, the results are stored (separate to the stateful storage). If later on, you're about to visit a page with remembered results, we use those results and skip that page (and subsequent pages if also remembered). At the very start, it skips the yes/no ID page if either ID or Site has been remembered.
If you go back to change a location-page using a change link, any subsequent remembered location stuff is forgotten, so you will be asked again. It also does not show the remember tickbox on location pages after the point you have stopped remembering, because we assume that is always drilling down (it still remembers reporter/contact details).

The page remembering stuff is pretty generic and copes with changes made to the HTML/flow (special case for that first page as above), but the 'forgetting' if you go back I have had to hard code a list of pages to forget, not sure if there's a better way of doing that, but it seems to work okay.

This also adds some display stuff to summary page to only show the relevant fields (hopefully) and get all the change links working.